### PR TITLE
Feature/Api Auth Generator

### DIFF
--- a/commands/MakeAuth.js
+++ b/commands/MakeAuth.js
@@ -66,16 +66,29 @@ class MakeAuth extends Command {
   }
 
   /**
-   * Creates the AuthController.js file.
+   * Creates the AuthController.js file for the HTTP client.
    *
    * @returns {Void}
    */
-  copyAuthController () {
+  copyHTTPAuthController () {
     this.copy(
       path.join(__dirname, '../templates', 'AuthController.js'),
       path.join(Helpers.appRoot(), 'app/Controllers/HTTP/AuthController.js')
     )
     this.success('Created Controllers/HTTP/AuthController.js')
+  }
+
+  /**
+   * Creates the ApiAuthController.js file for the HTTP client.
+   *
+   * @returns {Void}
+   */
+  copyApiAuthController () {
+    this.copy(
+      path.join(__dirname, '../templates', 'ApiAuthController.js'),
+      path.join(Helpers.appRoot(), 'app/Controllers/HTTP/ApiAuthController.js')
+    )
+    this.success('Created Controllers/HTTP/ApiAuthController.js')
   }
 
   /**
@@ -211,20 +224,31 @@ class MakeAuth extends Command {
   /**
    * Creates the app starter files available at app/start.
    *
+   * @param {String} client
    * @returns {Void}
    */
-  async copyAppStarterFiles () {
+  async copyAppStarterFiles (client) {
     try {
-      await this.copy(
-        path.join(__dirname, '../templates', 'authRoutes.js'),
-        path.join(Helpers.appRoot(), 'start/authRoutes.js')
-      )
+      if (client === 'http') {
+        await this.copy(
+          path.join(__dirname, '../templates', 'authRoutes.js'),
+          path.join(Helpers.appRoot(), 'start/authRoutes.js')
+        )
+      } else {
+        await this.copy(
+          path.join(__dirname, '../templates', 'apiAuthRoutes.js'),
+          path.join(Helpers.appRoot(), 'start/apiAuthRoutes.js')
+        )
+      }
+
       await this.copy(
         path.join(__dirname, '../templates', 'events.js'),
         path.join(Helpers.appRoot(), 'start/authEvents.js')
       )
 
-      this.success('Created start/authRoutes.js')
+      const authRoutesSuccessMessage = client ==='http' ? 'Created start/authRoutes.js': 'Created start/apiAuthRoutes.js';
+
+      this.success(authRoutesSuccessMessage)
       this.success('Created start/authEvents.js')
     } catch (error) {
       // ignore error
@@ -251,10 +275,16 @@ class MakeAuth extends Command {
   /**
    * Creates all scaffold templates.
    *
+   * @param {String} client - Specifies if we are generating for an API or HTTP client.
    * @returns {Void}
    */
-  async _copyFiles () {
-    await this.copyAuthController();
+  async _copyFiles (client) {
+    if (client === 'http') {
+      await this.copyHTTPAuthController();
+    } else {
+      await this.copyApiAuthController();
+    }
+
     await this.copyConfig()
     await this.copyAuthStyles()
     await this.copyEmailViewTemplates()
@@ -294,11 +324,9 @@ class MakeAuth extends Command {
 
     client = apiOnly ? 'api': 'http';
 
-    return console.log(client);
-
     try {
       await this._ensureInProjectRoot();
-      await this._copyFiles();
+      await this._copyFiles(client);
     } catch (error) {
       /**
        * Throw error if command executed programatically

--- a/commands/MakeAuth.js
+++ b/commands/MakeAuth.js
@@ -26,7 +26,11 @@ class MakeAuth extends Command {
    */
   /* istanbul ignore next */
   static get signature() {
-    return `make:auth`;
+    return `
+      make:auth
+      { --api-only : Generates files for RESTful Apis. }
+      { --http-only : Generates files for HTTP client request. }
+    `;
   }
 
   /* istanbul ignore next */
@@ -63,8 +67,8 @@ class MakeAuth extends Command {
 
   /**
    * Creates the AuthController.js file.
-   * 
-   * @returns {Void} 
+   *
+   * @returns {Void}
    */
   copyAuthController () {
     this.copy(
@@ -76,8 +80,8 @@ class MakeAuth extends Command {
 
   /**
    * Creates the adonis-auth-scaffold.js config file.
-   * 
-   * @returns {Void} 
+   *
+   * @returns {Void}
    */
   async copyConfig () {
     try {
@@ -93,8 +97,8 @@ class MakeAuth extends Command {
 
   /**
    * Creates the auth-styles.css file.
-   * 
-   * @returns {Void} 
+   *
+   * @returns {Void}
    */
   async copyAuthStyles () {
     try {
@@ -110,8 +114,8 @@ class MakeAuth extends Command {
 
   /**
    * Creates the email view templates files.
-   * 
-   * @returns {Void} 
+   *
+   * @returns {Void}
    */
   async copyEmailViewTemplates () {
     try {
@@ -133,8 +137,8 @@ class MakeAuth extends Command {
 
   /**
    * Creates the partials view templates.
-   * 
-   * @returns {Void} 
+   *
+   * @returns {Void}
    */
   async copyPartialsViewTemplates () {
     try {
@@ -156,8 +160,8 @@ class MakeAuth extends Command {
 
   /**
    * Creates the auth view templates.
-   * 
-   * @returns {Void} 
+   *
+   * @returns {Void}
    */
   async copyAuthViewTemplates () {
     try {
@@ -189,8 +193,8 @@ class MakeAuth extends Command {
 
   /**
    * Creates the layout view templates.
-   * 
-   * @returns {Void} 
+   *
+   * @returns {Void}
    */
   async copyLayoutViewTemplates () {
     try {
@@ -206,8 +210,8 @@ class MakeAuth extends Command {
 
   /**
    * Creates the app starter files available at app/start.
-   * 
-   * @returns {Void} 
+   *
+   * @returns {Void}
    */
   async copyAppStarterFiles () {
     try {
@@ -226,11 +230,11 @@ class MakeAuth extends Command {
       // ignore error
     }
   }
-  
+
   /**
    * Creates the app starter files available at app/start.
-   * 
-   * @returns {Void} 
+   *
+   * @returns {Void}
    */
   async copyMiddlewareFiles () {
     try {
@@ -246,8 +250,8 @@ class MakeAuth extends Command {
 
   /**
    * Creates all scaffold templates.
-   * 
-   * @returns {Void} 
+   *
+   * @returns {Void}
    */
   async _copyFiles () {
     await this.copyAuthController();
@@ -269,7 +273,29 @@ class MakeAuth extends Command {
    *
    * @return {void}
    */
-  async handle({}, {}) {
+  async handle({}, {
+    apiOnly,
+    httpOnly
+  }) {
+    let client;
+
+    if (!apiOnly && !httpOnly) {
+      client = await this
+        .choice('Will this be used for a REST Api or for a HTTP Client?', [
+          {
+            name: 'For REST Api',
+            value: 'api'
+          }, {
+            name: 'For HTTP',
+            value: 'http'
+          }
+        ])
+    }
+
+    client = apiOnly ? 'api': 'http';
+
+    return console.log(client);
+
     try {
       await this._ensureInProjectRoot();
       await this._copyFiles();

--- a/package-lock.json
+++ b/package-lock.json
@@ -997,8 +997,8 @@
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "requires": {
         "boom": "2.10.1",
-        "cryptiles": ">=4.1.2",
-        "hoek": ">=4.2.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
         "sntp": "1.0.9"
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "full-stack"
   ],
   "author": "Caleb Mathew <creatrixity@gmail.com>",
-  "license": "ISC",
-  "repository": "https://github.com/creatrixity/adonis-auth-scaffold"
+  "license": "GPL-3.0",
+  "repository": "https://github.com/creatrixity/adonis-auth-scaffold",
+  "private": false
 }

--- a/templates/ApiAuthController.js
+++ b/templates/ApiAuthController.js
@@ -1,0 +1,86 @@
+"use strict";
+const MAIL_PATTERN = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+const Persona = use("Persona");
+const Config = use("Config");
+const ReqPromise = use('request-promise');
+const fetch = use('node-fetch');
+
+const { validate } = use("Validator");
+
+class ApiAuthController {
+  async attemptLogin(auth, uid, password) {
+    // Determine which JWT authenticator will be used: Email or Username.
+    // If the uid value matches the test pattern, Email authentication is used.
+    let authBy = MAIL_PATTERN.test(uid) ? 'Email': 'Username';
+    const authScheme = `jwt${authBy}`;
+
+    return auth
+            .authenticator(authScheme)
+            .withRefreshToken()
+            .attempt(uid, password)
+  }
+
+  async login({ request, auth, response }) {
+    const { uid, password } = request.only(["uid", "password"]);
+
+    return this.attemptLogin(auth, uid, password);
+  }
+
+  async register({ request, auth, response }) {
+    const payload = request.only([
+      "email",
+      "username",
+      "password",
+      "password_confirmation"
+    ]);
+
+    const validation = await validate(
+      payload,
+      Config.get("adonis-auth-scaffold.validationRules.registration"),
+      Config.get("adonis-auth-scaffold.validationMessages")()
+    );
+
+    if (validation.fails()) {
+      return {
+        errors: validation.messages()
+      }
+    }
+
+    try {
+      const user = await Persona.register(payload);
+
+      return this.attemptLogin(auth, payload.email, payload.password);
+    } catch (error) {
+      return {
+        error
+      }
+    }
+  }
+
+  async forgotPassword({ request, response, auth }) {
+    const payload = request.only(['password', 'password_confirmation', 'token', 'uid']);
+    const { token, uid, password } = payload
+
+    if (!token) {
+      const passwordRequest = await Persona.forgotPassword(uid);
+      return {
+        message: 'Successfully sent reset message'
+      }
+    }
+
+    try {
+      const user = await Persona.updatePasswordByToken(token, payload);
+
+      return await this.attemptLogin(auth, uid, password);
+    } catch (error) {
+      if (error.name === 'InvalidTokenException') {
+        return {
+          errorMessage: 'The token supplied is not valid.'
+        }
+      }
+    }
+  }
+}
+
+module.exports = ApiAuthController;

--- a/templates/apiAuthRoutes.js
+++ b/templates/apiAuthRoutes.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const Config = use("Config");
+/*
+|--------------------------------------------------------------------------
+| API Auth Routes
+|--------------------------------------------------------------------------
+|
+| Http routes are entry points to your web application. You can create
+| routes for different URL's and bind Controller actions to them.
+|
+| A complete guide on routing is available here.
+| http://adonisjs.com/docs/4.1/routing
+|
+*/
+
+/** @type {typeof import('@adonisjs/framework/src/Route/Manager')} */
+const Route = use("Route");
+const loginRoute = Config.get("adonis-auth-scaffold.loginRoute");
+const registerRoute = Config.get("adonis-auth-scaffold.registrationRoute");
+const passwordResetRoute = Config.get(
+  "adonis-auth-scaffold.passwordResetRoute"
+);
+const logoutRoute = Config.get("adonis-auth-scaffold.logoutRoute");
+
+Route.post(`api/v1${loginRoute}`, "ApiAuthController.login");
+Route.post(`api/v1${registerRoute}`, "ApiAuthController.register");
+Route.post(`api/v1${passwordResetRoute}`, "ApiAuthController.forgotPassword");
+Route.get(`api/v1${logoutRoute}`, "ApiAuthController.getLogout");


### PR DESCRIPTION
This commit adds the ability to choose between generating auth code for RESTful APIs or for traditional HTTP clients. The `--api-only` and `--http-only` flags can be passed to the cli to indicate the primary use case of the code to be generated.

![auth-api-scaffold](https://user-images.githubusercontent.com/5021686/54365412-10485200-466f-11e9-8fb5-cbaa920c6950.gif)

