### PR TITLE
Create migration for users table

### DIFF
--- a/commands/MakeAuth.js
+++ b/commands/MakeAuth.js
@@ -290,6 +290,25 @@ class MakeAuth extends Command {
   }
 
   /**
+   * Creates a migration for users table. 
+   *
+   * @returns {Void}
+   */
+  async copyMigrationFiles () {
+    try {
+      const timestamp = new Date().getTime();
+      const newFileName = `database/migrations/${timestamp}_add_account_status_to_users_schema.js`;
+      await this.copy(
+        path.join(__dirname, '../templates', 'migration_add_account_status_to_users_schema.js'),
+        path.join(Helpers.appRoot(), newFileName)
+      )
+      this.success(`Created ${newFileName}`)
+    } catch (error) {
+      this.error(error);
+    }
+  }
+
+  /**
    * Creates all scaffold templates.
    *
    * @param {String} client - Specifies if we are generating for an API or HTTP client.
@@ -310,6 +329,7 @@ class MakeAuth extends Command {
     await this.copyLayoutViewTemplates()
     await this.copyAppStarterFiles()
     await this.copyMiddlewareFiles()
+    await this.copyMigrationFiles()
   }
 
   /**

--- a/templates/migration_add_account_status_to_users_schema.js
+++ b/templates/migration_add_account_status_to_users_schema.js
@@ -1,0 +1,20 @@
+'use strict'
+
+/** @type {import('@adonisjs/lucid/src/Schema')} */
+const Schema = use('Schema')
+
+class AddAccountStatusToUsersSchema extends Schema {
+  up () {
+    this.table('users', (table) => {
+      table.string('account_status', 15).notNullable().defaultTo('pending');
+    })
+  }
+
+  down () {
+    this.table('users', (table) => {
+      table.dropColumn('account_status');
+    })
+  }
+}
+
+module.exports = AddAccountStatusToUsersSchema


### PR DESCRIPTION
Fix #16.

`adonis make:auth` now adds a migration to create the field account_status to the `users` table.

This is a requirement of [Adonis Persona](https://github.com/adonisjs/adonis-persona).