### PR TITLE
Show more errors during auth

### DIFF
--- a/templates/AuthController.js
+++ b/templates/AuthController.js
@@ -59,6 +59,8 @@ class AuthController {
     } catch (error) {
       if (error.name === 'InvalidTokenException') {
         session.flash({ errorMessage: 'The token supplied is not valid.' })
+      } else {
+        session.flash({ errorMessage: error.message })
       }
     }
 


### PR DESCRIPTION
The Forgot Password resource was showing only token-related errors.
This commits fixes this by showing the generic errors of error.message.